### PR TITLE
[ENH] Add  `max_candidate_split_points` hyperparameter

### DIFF
--- a/crates/partition_tree/examples/debug.rs
+++ b/crates/partition_tree/examples/debug.rs
@@ -93,6 +93,7 @@ fn main() {
         &dataset,
         &loss,
         &restrictions,
+        None,
         4.0,
     );
     match &result {
@@ -114,6 +115,7 @@ fn main() {
         &dataset,
         &loss,
         &restrictions,
+        None,
         4.0,
     );
     match &result2 {

--- a/crates/partition_tree/src/column_split/categorical.rs
+++ b/crates/partition_tree/src/column_split/categorical.rs
@@ -4,7 +4,7 @@
 //! prefix scan algorithm.
 use std::collections::HashSet;
 
-use super::{ColumnSplitSearcher, cumsum};
+use super::{ColumnSplitSearcher, clip_candidate_positions, cumsum};
 use crate::cell::Cell;
 use crate::dataset_view::{ColumnView, DatasetView};
 use crate::loss::{CellStats, LossFunc};
@@ -46,6 +46,7 @@ impl ColumnSplitSearcher for CategoricalColumnSplitSearcher {
         dataset: &dyn DatasetView,
         loss: &dyn LossFunc,
         restrictions: &SplitRestrictions,
+        max_candidate_split_points: Option<usize>,
         dataset_size: f64,
     ) -> Option<SplitPoint> {
         let col_name = col.name();
@@ -129,11 +130,18 @@ impl ColumnSplitSearcher for CategoricalColumnSplitSearcher {
 
         let mut best: Option<SplitPoint> = None;
         let mut best_gain = f64::NEG_INFINITY;
+        let valid_candidate_positions: Vec<usize> = (0..cats.len() - 1).collect();
+        let candidate_positions =
+            clip_candidate_positions(&valid_candidate_positions, max_candidate_split_points);
+
+        if candidate_positions.is_empty() {
+            return None;
+        }
 
         // Try both none_to_left options
         for &none_to_left in &[true, false] {
             // 3) Scan prefix splits
-            for t in 0..cats.len() - 1 {
+            for &t in &candidate_positions {
                 let a_left = a_pref[t];
                 let b_left = b_pref[t];
                 let a_right = a_total - a_left;

--- a/crates/partition_tree/src/column_split/continuous.rs
+++ b/crates/partition_tree/src/column_split/continuous.rs
@@ -2,7 +2,7 @@
 //!
 //! Handles `Float64`, `Float32` and similar continuous numeric columns
 //! using a presorted scan with a moving XY pointer.
-use super::{ColumnSplitSearcher, cumsum, split_nulls};
+use super::{ColumnSplitSearcher, clip_candidate_positions, cumsum, split_nulls};
 use crate::cell::Cell;
 use crate::dataset_view::{ColumnView, DatasetView};
 use crate::loss::{CellStats, LossFunc};
@@ -45,6 +45,7 @@ impl ColumnSplitSearcher for ContinuousColumnSplitSearcher {
         dataset: &dyn DatasetView,
         loss: &dyn LossFunc,
         restrictions: &SplitRestrictions,
+        max_candidate_split_points: Option<usize>,
         dataset_size: f64,
     ) -> Option<SplitPoint> {
         let col_name = col.name();
@@ -83,6 +84,27 @@ impl ColumnSplitSearcher for ContinuousColumnSplitSearcher {
             return None;
         }
 
+        // Only keep boundaries where the sorted column value actually changes.
+        // If adjacent candidates have the same value, their midpoint would not
+        // separate any rows and therefore cannot produce a real split.
+        let valid_candidate_positions: Vec<usize> = (0..candidates.len() - 1)
+            .filter(|&k| {
+                let i0 = candidates[k] as usize;
+                let i1 = candidates[k + 1] as usize;
+
+                matches!(
+                    (col.get_f64(i0), col.get_f64(i1)),
+                    (Some(v0), Some(v1)) if (v0 - v1).abs() >= f64::EPSILON
+                )
+            })
+            .collect();
+        let candidate_positions =
+            clip_candidate_positions(&valid_candidate_positions, max_candidate_split_points);
+
+        if candidate_positions.is_empty() {
+            return None;
+        }
+
         // Prefix sums on candidate weights
         let candidate_weights: Vec<f64> = match split_kind {
             SplitKind::XSplit => candidates.iter().map(|&i| weights_x[i as usize]).collect(),
@@ -102,7 +124,7 @@ impl ColumnSplitSearcher for ContinuousColumnSplitSearcher {
         for &none_to_left in &[true, false] {
             let mut p_xy: usize = 0;
 
-            for k in 0..candidates.len() - 1 {
+            for &k in &candidate_positions {
                 let i0 = candidates[k] as usize;
                 let i1 = candidates[k + 1] as usize;
 
@@ -270,6 +292,7 @@ mod tests {
             &dataset,
             &loss,
             &restrictions,
+            None,
             5.0,
         );
 
@@ -296,6 +319,7 @@ mod tests {
             &dataset,
             &loss,
             &restrictions,
+            None,
             5.0,
         );
 

--- a/crates/partition_tree/src/column_split/integer.rs
+++ b/crates/partition_tree/src/column_split/integer.rs
@@ -2,7 +2,7 @@
 //!
 //! Handles `Int32` and `Int64` Polars columns using a presorted scan
 //! analogous to the continuous searcher but with integer thresholds.
-use super::{ColumnSplitSearcher, cumsum, split_nulls};
+use super::{ColumnSplitSearcher, clip_candidate_positions, cumsum, split_nulls};
 use crate::cell::Cell;
 use crate::dataset_view::{ColumnView, DatasetView};
 use crate::loss::{CellStats, LossFunc};
@@ -42,6 +42,7 @@ impl ColumnSplitSearcher for IntegerColumnSplitSearcher {
         dataset: &dyn DatasetView,
         loss: &dyn LossFunc,
         restrictions: &SplitRestrictions,
+        max_candidate_split_points: Option<usize>,
         dataset_size: f64,
     ) -> Option<SplitPoint> {
         let col_name = col.name();
@@ -80,6 +81,21 @@ impl ColumnSplitSearcher for IntegerColumnSplitSearcher {
             return None;
         }
 
+        let valid_candidate_positions: Vec<usize> = (0..candidates.len() - 1)
+            .filter(|&k| {
+                let i0 = candidates[k] as usize;
+                let i1 = candidates[k + 1] as usize;
+
+                matches!((col.get_i64(i0), col.get_i64(i1)), (Some(v0), Some(v1)) if v0 != v1)
+            })
+            .collect();
+        let candidate_positions =
+            clip_candidate_positions(&valid_candidate_positions, max_candidate_split_points);
+
+        if candidate_positions.is_empty() {
+            return None;
+        }
+
         // Prefix sums on candidate weights
         let candidate_weights: Vec<f64> = match split_kind {
             SplitKind::XSplit => candidates.iter().map(|&i| weights_x[i as usize]).collect(),
@@ -99,7 +115,7 @@ impl ColumnSplitSearcher for IntegerColumnSplitSearcher {
         for &none_to_left in &[true, false] {
             let mut p_xy: usize = 0;
 
-            for k in 0..candidates.len() - 1 {
+            for &k in &candidate_positions {
                 let i0 = candidates[k] as usize;
                 let i1 = candidates[k + 1] as usize;
 

--- a/crates/partition_tree/src/column_split/mod.rs
+++ b/crates/partition_tree/src/column_split/mod.rs
@@ -65,6 +65,7 @@ pub trait ColumnSplitSearcher: Send + Sync {
         dataset: &dyn DatasetView,
         loss: &dyn LossFunc,
         restrictions: &SplitRestrictions,
+        max_candidate_split_points: Option<usize>,
         dataset_size: f64,
     ) -> Option<SplitPoint>;
 }
@@ -103,6 +104,36 @@ pub(crate) fn cumsum(values: &[f64]) -> Vec<f64> {
     result
 }
 
+/// Deterministically clip valid candidate split positions.
+///
+/// The input is assumed to already contain only valid split boundaries. When a
+/// cap is provided, we keep a deterministic subset that spans the full range of
+/// positions instead of taking the first `max` entries.
+pub(crate) fn clip_candidate_positions(
+    candidate_positions: &[usize],
+    max_candidate_split_points: Option<usize>,
+) -> Vec<usize> {
+    let total = candidate_positions.len();
+
+    match max_candidate_split_points {
+        _ if total == 0 => Vec::new(),
+        None => candidate_positions.to_vec(),
+        Some(0) => Vec::new(),
+        Some(max) if max >= total => candidate_positions.to_vec(),
+        // With a single retained candidate, choose the middle valid position.
+        Some(1) => vec![candidate_positions[total / 2]],
+        Some(max) => (0..max)
+            .map(|slot| {
+                // Map each output slot onto the closed interval [0, total - 1]
+                // so the retained candidates are spread across the full search
+                // range and remain stable across runs.
+                let idx = slot * (total - 1) / (max - 1);
+                candidate_positions[idx]
+            })
+            .collect(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -116,5 +147,24 @@ mod tests {
         let v = vec![1.0, 2.0, 3.0, 4.0];
         let cs = cumsum(&v);
         assert_eq!(cs, vec![1.0, 3.0, 6.0, 10.0]);
+    }
+
+    #[test]
+    fn clip_candidate_positions_preserves_all_when_unbounded() {
+        let positions = vec![1, 3, 4, 8, 10];
+
+        assert_eq!(clip_candidate_positions(&positions, None), positions);
+    }
+
+    #[test]
+    fn clip_candidate_positions_samples_evenly() {
+        let positions = vec![1, 3, 4, 8, 10];
+
+        assert_eq!(
+            clip_candidate_positions(&positions, Some(3)),
+            vec![1, 4, 10]
+        );
+        assert_eq!(clip_candidate_positions(&positions, Some(1)), vec![4]);
+        assert!(clip_candidate_positions(&positions, Some(0)).is_empty());
     }
 }

--- a/crates/partition_tree/src/column_split/quantized_continuous.rs
+++ b/crates/partition_tree/src/column_split/quantized_continuous.rs
@@ -2,7 +2,7 @@
 //!
 //! Handles numeric columns by snapping values to bins centered on
 //! `resolution * i` and using integer-style split thresholds on the bin indices.
-use super::{ColumnSplitSearcher, cumsum, split_nulls};
+use super::{ColumnSplitSearcher, clip_candidate_positions, cumsum, split_nulls};
 use crate::cell::Cell;
 use crate::dataset_view::{ColumnView, DatasetView, LogicalDType};
 use crate::loss::{CellStats, LossFunc};
@@ -25,6 +25,7 @@ impl ColumnSplitSearcher for QuantizedContinuousColumnSplitSearcher {
         dataset: &dyn DatasetView,
         loss: &dyn LossFunc,
         restrictions: &SplitRestrictions,
+        max_candidate_split_points: Option<usize>,
         dataset_size: f64,
     ) -> Option<SplitPoint> {
         let spec = match col.logical_dtype() {
@@ -79,6 +80,21 @@ impl ColumnSplitSearcher for QuantizedContinuousColumnSplitSearcher {
             return None;
         }
 
+        let valid_candidate_positions: Vec<usize> = (0..candidates.len() - 1)
+            .filter(|&k| {
+                let i0 = candidates[k] as usize;
+                let i1 = candidates[k + 1] as usize;
+
+                matches!((col.get_f64(i0), col.get_f64(i1)), (Some(v0), Some(v1)) if quantize(v0) != quantize(v1))
+            })
+            .collect();
+        let candidate_positions =
+            clip_candidate_positions(&valid_candidate_positions, max_candidate_split_points);
+
+        if candidate_positions.is_empty() {
+            return None;
+        }
+
         let candidate_weights: Vec<f64> = match split_kind {
             SplitKind::XSplit => candidates.iter().map(|&i| weights_x[i as usize]).collect(),
             SplitKind::YSplit => candidates.iter().map(|&i| weights_y[i as usize]).collect(),
@@ -95,7 +111,7 @@ impl ColumnSplitSearcher for QuantizedContinuousColumnSplitSearcher {
         for &none_to_left in &[true, false] {
             let mut p_xy: usize = 0;
 
-            for k in 0..candidates.len() - 1 {
+            for &k in &candidate_positions {
                 let i0 = candidates[k] as usize;
                 let i1 = candidates[k + 1] as usize;
 
@@ -237,6 +253,7 @@ mod tests {
             &dataset,
             &loss,
             &restrictions,
+            None,
             5.0,
         );
 

--- a/crates/partition_tree/src/estimators/forest.rs
+++ b/crates/partition_tree/src/estimators/forest.rs
@@ -95,6 +95,9 @@ pub struct PartitionForest {
     /// Fraction of feature columns to consider at each split.
     /// `None` means use all features.
     pub max_features: Option<f64>,
+    /// Maximum number of candidate split points evaluated per column during a
+    /// split search. `None` means consider every valid candidate.
+    pub max_candidate_split_points: Option<usize>,
     /// Per-column logical dtype overrides applied during fit and prediction.
     pub dtype_overrides: HashMap<String, LogicalDType>,
 
@@ -143,6 +146,7 @@ impl PartitionForest {
             max_samples: max_samples,
             replace: replace,
             max_features: max_features,
+            max_candidate_split_points: None,
             dtype_overrides,
             loss: loss,
             seed: seed,
@@ -169,6 +173,7 @@ impl PartitionForest {
             max_samples: None,
             replace: true,
             max_features: None,
+            max_candidate_split_points: None,
             dtype_overrides: HashMap::new(),
             loss: None,
             trees: None,
@@ -341,6 +346,7 @@ impl PartitionForest {
             max_samples: self.max_samples,
             replace: self.replace,
             max_features: self.max_features,
+            max_candidate_split_points: self.max_candidate_split_points,
             seed: None, // seed is set per-tree in _fit_impl
         }
     }
@@ -442,6 +448,7 @@ impl Estimator for PartitionForest {
                     max_samples: config_template.max_samples,
                     replace: config_template.replace,
                     max_features: config_template.max_features,
+                    max_candidate_split_points: config_template.max_candidate_split_points,
                     seed: Some((base_seed + idx) as u64),
                 };
                 let loss: Box<dyn LossFunc> = loss_factory.clone_box();
@@ -470,6 +477,7 @@ impl Estimator for PartitionForest {
             max_samples: self.max_samples,
             replace: self.replace,
             max_features: self.max_features,
+            max_candidate_split_points: self.max_candidate_split_points,
             dtype_overrides: self.dtype_overrides.clone(),
             loss: Some(loss_factory),
             trees: self.trees.take(),

--- a/crates/partition_tree/src/estimators/tree.rs
+++ b/crates/partition_tree/src/estimators/tree.rs
@@ -81,6 +81,9 @@ pub struct PartitionTree {
     /// Fraction of feature columns to consider at each split.
     /// `None` means use all features.
     pub max_features: Option<f64>,
+    /// Maximum number of candidate split points evaluated per column during a
+    /// split search. `None` means consider every valid candidate.
+    pub max_candidate_split_points: Option<usize>,
     // Loss function to be used
     pub loss: Option<Box<dyn LossFunc>>,
     /// RNG seed for reproducible bootstrap / feature subsampling.
@@ -132,6 +135,7 @@ impl PartitionTree {
             max_samples,
             replace,
             max_features,
+            max_candidate_split_points: None,
             loss,
             seed,
             dtype_overrides,
@@ -156,6 +160,7 @@ impl PartitionTree {
             max_samples: None,
             replace: true,
             max_features: None,
+            max_candidate_split_points: None,
             loss: None,
             seed: None,
             dtype_overrides: HashMap::new(),
@@ -293,6 +298,7 @@ impl PartitionTree {
             max_samples: self.max_samples,
             replace: self.replace,
             max_features: self.max_features,
+            max_candidate_split_points: self.max_candidate_split_points,
             seed: self.seed,
         }
     }
@@ -376,6 +382,7 @@ impl Estimator for PartitionTree {
             max_samples: self.max_samples,
             replace: self.replace,
             max_features: self.max_features,
+            max_candidate_split_points: self.max_candidate_split_points,
             loss: Some(loss),
             seed: self.seed,
             dtype_overrides: self.dtype_overrides.clone(),

--- a/crates/partition_tree/src/split_searcher.rs
+++ b/crates/partition_tree/src/split_searcher.rs
@@ -53,6 +53,7 @@ impl SplitSearcher {
         loss: &dyn LossFunc,
         restrictions: &SplitRestrictions,
         max_features: Option<usize>,
+        max_candidate_split_points: Option<usize>,
         rng: &mut StdRng,
         dataset_size: f64,
     ) -> Option<SplitPoint> {
@@ -110,6 +111,7 @@ impl SplitSearcher {
                     dataset,
                     loss,
                     restrictions,
+                    max_candidate_split_points,
                     dataset_size,
                 )
             })
@@ -187,8 +189,16 @@ mod tests {
         let restrictions = SplitRestrictions::default();
         let mut rng = StdRng::seed_from_u64(42);
 
-        let result =
-            searcher.find_best_split(&node, &dataset, &loss, &restrictions, None, &mut rng, 5.0);
+        let result = searcher.find_best_split(
+            &node,
+            &dataset,
+            &loss,
+            &restrictions,
+            None,
+            None,
+            &mut rng,
+            5.0,
+        );
 
         assert!(result.is_some(), "should find a valid split");
         let split = result.unwrap();
@@ -213,6 +223,7 @@ mod tests {
             &loss,
             &restrictions,
             Some(1),
+            None,
             &mut rng,
             5.0,
         );
@@ -292,6 +303,7 @@ mod tests {
                 &loss,
                 &restrictions,
                 Some(1),
+                None,
                 &mut rng,
                 5.0,
             ) {

--- a/crates/partition_tree/src/tree_builder.rs
+++ b/crates/partition_tree/src/tree_builder.rs
@@ -56,6 +56,9 @@ pub struct TreeBuilderConfig {
     /// Fraction of *feature* columns to consider at each split. `None` means
     /// use all features (default). Target columns are always included.
     pub max_features: Option<f64>,
+    /// Maximum number of candidate split points evaluated per column during a
+    /// split search. `None` means evaluate every valid candidate.
+    pub max_candidate_split_points: Option<usize>,
     /// RNG seed for reproducible bootstrap / feature subsampling.
     /// `None` uses OS entropy.
     pub seed: Option<u64>,
@@ -70,6 +73,7 @@ impl Default for TreeBuilderConfig {
             max_samples: None,
             replace: true,
             max_features: None,
+            max_candidate_split_points: None,
             seed: None,
         }
     }
@@ -179,6 +183,7 @@ impl TreeBuilder {
                 self.loss.as_ref(),
                 &self.config.restrictions,
                 max_features_count,
+                self.config.max_candidate_split_points,
                 &mut rng,
                 dataset_size,
             ) {
@@ -294,6 +299,7 @@ impl TreeBuilder {
                         self.loss.as_ref(),
                         &self.config.restrictions,
                         max_features_count,
+                        self.config.max_candidate_split_points,
                         &mut rng,
                         dataset_size,
                     ) {
@@ -521,6 +527,7 @@ mod tests {
             max_samples: Some(0.5),
             replace: true,
             max_features: None,
+            max_candidate_split_points: None,
             seed: Some(42),
         };
         let loss = Box::new(ConditionalLogLoss);
@@ -552,6 +559,7 @@ mod tests {
             max_samples: None,
             replace: true,
             max_features: Some(0.5),
+            max_candidate_split_points: None,
             seed: Some(42),
         };
         let loss = Box::new(ConditionalLogLoss);
@@ -579,6 +587,7 @@ mod tests {
                 max_samples: Some(0.7),
                 replace: true,
                 max_features: Some(0.5),
+                max_candidate_split_points: None,
                 seed: Some(seed),
             };
             let loss = Box::new(ConditionalLogLoss);
@@ -617,6 +626,7 @@ mod tests {
                 max_samples: Some(0.5),
                 replace: true,
                 max_features: Some(0.5),
+                max_candidate_split_points: None,
                 seed: Some(seed),
             };
             let loss = Box::new(ConditionalLogLoss);
@@ -648,5 +658,22 @@ mod tests {
             "different seeds with max_samples + max_features should produce \
              different trees for at least one seed pair"
         );
+    }
+
+    #[test]
+    fn max_candidate_split_points_zero_disables_splits() {
+        let dataset = make_dataset();
+        let config = TreeBuilderConfig {
+            max_candidate_split_points: Some(0),
+            ..Default::default()
+        };
+        let loss = Box::new(ConditionalLogLoss);
+        let registry = Arc::new(DTypeRegistry::default());
+        let builder = TreeBuilder::new(config, loss, registry);
+
+        let tree = builder.build(&dataset);
+
+        assert_eq!(tree.n_leaves(), 1, "no candidates means no split");
+        assert!(tree.split_history.is_empty(), "split history should stay empty");
     }
 }

--- a/partition_tree/src/partition_tree/sklearn/partition_tree.py
+++ b/partition_tree/src/partition_tree/sklearn/partition_tree.py
@@ -224,6 +224,7 @@ class PartitionTreeClassifier(ClassifierMixin, BaseEstimator):
         min_volume_fraction=0.0,
         max_depth=None,
         min_samples_split=2.0,
+        max_candidate_split_points=None,
         loss=None,
         random_state=42,
         dtype_overrides=None,
@@ -237,6 +238,7 @@ class PartitionTreeClassifier(ClassifierMixin, BaseEstimator):
         self.min_volume_fraction = min_volume_fraction
         self.max_depth = max_depth
         self.min_samples_split = min_samples_split
+        self.max_candidate_split_points = max_candidate_split_points
         self.loss = loss
         self.random_state = random_state
         self.dtype_overrides = dtype_overrides
@@ -261,6 +263,7 @@ class PartitionTreeClassifier(ClassifierMixin, BaseEstimator):
             min_volume_fraction=self.min_volume_fraction,
             max_depth=self._max_depth,
             min_samples_split=self.min_samples_split,
+            max_candidate_split_points=self.max_candidate_split_points,
             loss=self.loss,
             seed=self.random_state,
             dtype_overrides=self.dtype_overrides,
@@ -348,6 +351,7 @@ class PartitionForestClassifier(ClassifierMixin, BaseEstimator):
         max_samples=0.8,
         replace=True,
         max_features=0.8,
+        max_candidate_split_points=None,
         loss=None,
         random_state=None,
     ):
@@ -364,6 +368,7 @@ class PartitionForestClassifier(ClassifierMixin, BaseEstimator):
         self.max_samples = max_samples
         self.replace = replace
         self.max_features = max_features
+        self.max_candidate_split_points = max_candidate_split_points
         self.loss = loss
         self.random_state = random_state
         super().__init__()
@@ -391,6 +396,7 @@ class PartitionForestClassifier(ClassifierMixin, BaseEstimator):
             max_samples=self.max_samples,
             replace=self.replace,
             max_features=self.max_features,
+            max_candidate_split_points=self.max_candidate_split_points,
             loss=self.loss,
             seed=self.random_state,
         )
@@ -465,6 +471,7 @@ class PartitionTreeRegressor(RegressorMixin, BaseEstimator):
         min_volume_fraction=0.1,
         max_depth=None,
         min_samples_split=2.0,
+        max_candidate_split_points=None,
         loss=None,
         random_state=42,
         dtype_overrides="auto",
@@ -478,6 +485,7 @@ class PartitionTreeRegressor(RegressorMixin, BaseEstimator):
         self.min_volume_fraction = min_volume_fraction
         self.max_depth = max_depth
         self.min_samples_split = min_samples_split
+        self.max_candidate_split_points = max_candidate_split_points
         self.loss = loss
         self.random_state = random_state
         self.dtype_overrides = dtype_overrides
@@ -514,6 +522,7 @@ class PartitionTreeRegressor(RegressorMixin, BaseEstimator):
             min_volume_fraction=self.min_volume_fraction,
             max_depth=self._max_depth,
             min_samples_split=self.min_samples_split,
+            max_candidate_split_points=self.max_candidate_split_points,
             loss=self.loss,
             seed=self.random_state,
             dtype_overrides=resolved_dtype_overrides,
@@ -572,6 +581,7 @@ class PartitionForestRegressor(RegressorMixin, BaseEstimator):
         max_samples=0.8,
         replace=True,
         max_features=0.8,
+        max_candidate_split_points=None,
         loss=None,
         random_state=42,
         dtype_overrides="auto",
@@ -589,6 +599,7 @@ class PartitionForestRegressor(RegressorMixin, BaseEstimator):
         self.max_samples = max_samples
         self.replace = replace
         self.max_features = max_features
+        self.max_candidate_split_points = max_candidate_split_points
         self.loss = loss
         self.random_state = random_state
         self.dtype_overrides = dtype_overrides
@@ -629,6 +640,7 @@ class PartitionForestRegressor(RegressorMixin, BaseEstimator):
             max_samples=self.max_samples,
             replace=self.replace,
             max_features=self.max_features,
+            max_candidate_split_points=self.max_candidate_split_points,
             loss=self.loss,
             seed=self.random_state,
             dtype_overrides=resolved_dtype_overrides,

--- a/partition_tree/src/partition_tree/skpro/partition_tree.py
+++ b/partition_tree/src/partition_tree/skpro/partition_tree.py
@@ -34,6 +34,7 @@ class PartitionTreeRegressor(BaseProbaRegressor):
         min_volume_fraction=0.1,
         max_depth=None,
         min_samples_split=2.0,
+        max_candidate_split_points=None,
         loss=None,
         random_state=42,
         dtype_overrides="auto",
@@ -47,6 +48,7 @@ class PartitionTreeRegressor(BaseProbaRegressor):
         self.min_volume_fraction = min_volume_fraction
         self.max_depth = max_depth
         self.min_samples_split = min_samples_split
+        self.max_candidate_split_points = max_candidate_split_points
         self.loss = loss
         self.random_state = random_state
         self.dtype_overrides = dtype_overrides
@@ -79,6 +81,7 @@ class PartitionTreeRegressor(BaseProbaRegressor):
             min_volume_fraction=self.min_volume_fraction,
             max_depth=self._max_depth,
             min_samples_split=self.min_samples_split,
+            max_candidate_split_points=self.max_candidate_split_points,
             loss=self.loss,
             seed=self.random_state,
             dtype_overrides=resolved_dtype_overrides,
@@ -186,6 +189,7 @@ class PartitionForestRegressor(BaseProbaRegressor):
         max_samples=1.0,
         replace=True,
         max_features=1.0,
+        max_candidate_split_points=None,
         loss=None,
         output_distribution="merged",
         random_state=42,
@@ -220,6 +224,7 @@ class PartitionForestRegressor(BaseProbaRegressor):
         self.max_samples = max_samples
         self.replace = replace
         self.max_features = max_features
+        self.max_candidate_split_points = max_candidate_split_points
         self.loss = loss
         self.random_state = random_state
         self.output_distribution = output_distribution
@@ -257,6 +262,7 @@ class PartitionForestRegressor(BaseProbaRegressor):
             max_features=self.max_features,
             max_samples=self.max_samples,
             replace=self.replace,
+            max_candidate_split_points=self.max_candidate_split_points,
             loss=self.loss,
             seed=self.random_state,
             dtype_overrides=resolved_dtype_overrides,

--- a/partition_tree/tests/skpro/test_skpro_estimators.py
+++ b/partition_tree/tests/skpro/test_skpro_estimators.py
@@ -13,7 +13,6 @@ from partition_tree.skpro import (
 )
 from partition_tree.skpro.distribution import IntervalDistribution
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -168,6 +167,21 @@ class TestPartitionForestEndToEnd:
         dist = model.predict_proba(X_test)
         samples = dist.sample(n_samples=10)
         assert samples.shape[0] == 10 * X_test.shape[0]
+
+
+def test_skpro_estimators_expose_max_candidate_split_points_parameter():
+    tree = PartitionTreeRegressor(
+        max_leaves=20, max_depth=5, max_candidate_split_points=7
+    )
+    forest = PartitionForestRegressor(
+        n_estimators=5,
+        max_leaves=20,
+        max_depth=5,
+        max_candidate_split_points=11,
+    )
+
+    assert tree.get_params()["max_candidate_split_points"] == 7
+    assert forest.get_params()["max_candidate_split_points"] == 11
 
 
 # ---------------------------------------------------------------------------

--- a/pyo3_partition_tree/src/lib.rs
+++ b/pyo3_partition_tree/src/lib.rs
@@ -206,6 +206,7 @@ impl PyPartitionTree {
         max_samples = None,
         replace = true,
         max_features = None,
+        max_candidate_split_points = None,
         loss = None,
         seed = None,
         dtype_overrides = None,
@@ -224,6 +225,7 @@ impl PyPartitionTree {
         max_samples: Option<f64>,
         replace: bool,
         max_features: Option<f64>,
+        max_candidate_split_points: Option<usize>,
         loss: Option<String>,
         seed: Option<u64>,
         dtype_overrides: Option<Py<PyDict>>,
@@ -245,8 +247,7 @@ impl PyPartitionTree {
         }?;
         let dtype_overrides = parse_dtype_overrides(py, dtype_overrides)?;
 
-        Ok(Self {
-            inner: PartitionTree::new(
+        let mut inner = PartitionTree::new(
                 max_leaves,
                 boundaries_expansion_factor,
                 min_samples_xy,
@@ -262,8 +263,10 @@ impl PyPartitionTree {
                 loss_obj,
                 seed,
                 dtype_overrides,
-            ),
-        })
+            );
+        inner.max_candidate_split_points = max_candidate_split_points;
+
+        Ok(Self { inner })
     }
 
     pub fn fit(
@@ -547,6 +550,7 @@ impl PyPartitionForest {
         max_samples = None,
         replace = true,
         max_features = None,
+        max_candidate_split_points = None,
         loss = None,
         seed = None,
         dtype_overrides = None,
@@ -566,6 +570,7 @@ impl PyPartitionForest {
         max_samples: Option<f64>,
         replace: bool,
         max_features: Option<f64>,
+        max_candidate_split_points: Option<usize>,
         loss: Option<String>,
         seed: Option<usize>,
         dtype_overrides: Option<Py<PyDict>>,
@@ -587,8 +592,7 @@ impl PyPartitionForest {
         }?;
         let dtype_overrides = parse_dtype_overrides(py, dtype_overrides)?;
 
-        Ok(Self {
-            inner: PartitionForest::new(
+        let mut inner = PartitionForest::new(
                 n_estimators,
                 max_leaves,
                 boundaries_expansion_factor,
@@ -605,8 +609,10 @@ impl PyPartitionForest {
                 loss_obj,
                 seed,
                 dtype_overrides,
-            ),
-        })
+            );
+        inner.max_candidate_split_points = max_candidate_split_points;
+
+        Ok(Self { inner })
     }
 
     pub fn fit(

--- a/tests/test_partition_tree_regressor.py
+++ b/tests/test_partition_tree_regressor.py
@@ -194,3 +194,30 @@ def test_partition_forest_regressor_auto_dtype_override_detects_quantized_resolu
     nodes = model.partition_tree_.get_nodes_info()
     assert nodes[0][0]["partitions"]["x1"]["type"] == "quantized_continuous"
     assert nodes[0][0]["partitions"]["x1"]["resolution"] == pytest.approx(0.5)
+
+
+def test_max_candidate_split_points_zero_prevents_sklearn_tree_and_forest_splits():
+    X = pd.DataFrame({"x1": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
+    y = pd.Series([10.0, 10.0, 10.0, 20.0, 20.0, 20.0], name="target")
+
+    tree = PartitionTreeRegressor(
+        max_depth=5,
+        min_samples_split=2,
+        max_candidate_split_points=0,
+        random_state=42,
+    )
+    forest = PartitionForestRegressor(
+        n_estimators=3,
+        max_depth=5,
+        min_samples_split=2,
+        max_candidate_split_points=0,
+        random_state=42,
+    )
+
+    tree.fit(X, y)
+    forest.fit(X, y)
+
+    assert tree.get_params()["max_candidate_split_points"] == 0
+    assert forest.get_params()["max_candidate_split_points"] == 0
+    assert tree.partition_tree_.get_split_history() == []
+    assert all(history == [] for history in forest.partition_tree_.get_split_history())


### PR DESCRIPTION
This pull request introduces a mechanism to limit the number of candidate split points considered during column splitting in decision tree/forest algorithms. The main change is the addition of an optional `max_candidate_split_points` parameter, which deterministically samples a subset of valid split candidates for each column. This helps improve efficiency and stability when handling columns with many possible split points. The logic is applied consistently across categorical, continuous, integer, and quantized continuous column types, and the relevant configuration is plumbed through both tree and forest estimators.

**Core logic for candidate split point clipping:**

* Added a new utility function `clip_candidate_positions` to deterministically select a subset of candidate split positions, ensuring even coverage and reproducibility. Includes comprehensive unit tests for this logic. (F964d52eL104R104, [crates/partition_tree/src/column_split/mod.rsR151-R169](diffhunk://#diff-d4cd1485541b4ea2d515b39623c77fc30bc241927a8fb673deb707ee7578a542R151-R169))

**Column split searchers now support candidate clipping:**

* Updated `ColumnSplitSearcher` trait and all its implementations (`categorical.rs`, `continuous.rs`, `integer.rs`, `quantized_continuous.rs`) to accept an optional `max_candidate_split_points` argument and apply the new clipping logic. This ensures that only a limited, well-distributed set of valid split points are evaluated. [[1]](diffhunk://#diff-d4cd1485541b4ea2d515b39623c77fc30bc241927a8fb673deb707ee7578a542R68) [[2]](diffhunk://#diff-04628eab47e24006a704c0a5a08d6a45f16606b1ef1bdc9e54a241e752bd635bR49) [[3]](diffhunk://#diff-e57cc45fedbe65320455a863e3b4e072c1d8955a96b4b93c69785bcc16bcde22R48) [[4]](diffhunk://#diff-dd1df69ab1433cd763ed6a0739c7617e02c4379ae30a4af89a6141cc4d71f33cR45) [[5]](diffhunk://#diff-488618aa88a5d7e119fa584b670fbfc820332122276d6f5640c6f931057abf24R28) [[6]](diffhunk://#diff-04628eab47e24006a704c0a5a08d6a45f16606b1ef1bdc9e54a241e752bd635bR133-R144) [[7]](diffhunk://#diff-e57cc45fedbe65320455a863e3b4e072c1d8955a96b4b93c69785bcc16bcde22R87-R107) [[8]](diffhunk://#diff-dd1df69ab1433cd763ed6a0739c7617e02c4379ae30a4af89a6141cc4d71f33cR84-R98) [[9]](diffhunk://#diff-488618aa88a5d7e119fa584b670fbfc820332122276d6f5640c6f931057abf24R83-R97) [[10]](diffhunk://#diff-e57cc45fedbe65320455a863e3b4e072c1d8955a96b4b93c69785bcc16bcde22L105-R127) [[11]](diffhunk://#diff-dd1df69ab1433cd763ed6a0739c7617e02c4379ae30a4af89a6141cc4d71f33cL102-R118) [[12]](diffhunk://#diff-488618aa88a5d7e119fa584b670fbfc820332122276d6f5640c6f931057abf24L98-R114)

**Integration into estimators:**

* Added the `max_candidate_split_points` field to both `PartitionTree` and `PartitionForest` structs, with appropriate propagation through constructors, configuration, and cloning logic. [[1]](diffhunk://#diff-ee88a201c70eec955ddd7d90a5ec8e9c436c16664cd6623deb72a42129eee850R98-R100) [[2]](diffhunk://#diff-b51d4d3d8f75a24c3ef496d23e7937a33651163cd8aa29bf0963950380384f99R84-R86) [[3]](diffhunk://#diff-ee88a201c70eec955ddd7d90a5ec8e9c436c16664cd6623deb72a42129eee850R149) [[4]](diffhunk://#diff-b51d4d3d8f75a24c3ef496d23e7937a33651163cd8aa29bf0963950380384f99R138) [[5]](diffhunk://#diff-ee88a201c70eec955ddd7d90a5ec8e9c436c16664cd6623deb72a42129eee850R176) F1f78851L341R346, [[6]](diffhunk://#diff-ee88a201c70eec955ddd7d90a5ec8e9c436c16664cd6623deb72a42129eee850R451) [[7]](diffhunk://#diff-ee88a201c70eec955ddd7d90a5ec8e9c436c16664cd6623deb72a42129eee850R480) [[8]](diffhunk://#diff-b51d4d3d8f75a24c3ef496d23e7937a33651163cd8aa29bf0963950380384f99R163)

**Test updates:**

* Updated and added tests for the new clipping logic and to ensure compatibility with the new API signature in split searcher tests. [[1]](diffhunk://#diff-d4cd1485541b4ea2d515b39623c77fc30bc241927a8fb673deb707ee7578a542R151-R169) [[2]](diffhunk://#diff-e57cc45fedbe65320455a863e3b4e072c1d8955a96b4b93c69785bcc16bcde22R295) [[3]](diffhunk://#diff-e57cc45fedbe65320455a863e3b4e072c1d8955a96b4b93c69785bcc16bcde22R322) [[4]](diffhunk://#diff-488618aa88a5d7e119fa584b670fbfc820332122276d6f5640c6f931057abf24R256)

**Refactoring and imports:**

* Refactored imports in affected files to include the new utility function and maintain clarity. [[1]](diffhunk://#diff-04628eab47e24006a704c0a5a08d6a45f16606b1ef1bdc9e54a241e752bd635bL7-R7) [[2]](diffhunk://#diff-e57cc45fedbe65320455a863e3b4e072c1d8955a96b4b93c69785bcc16bcde22L5-R5) [[3]](diffhunk://#diff-dd1df69ab1433cd763ed6a0739c7617e02c4379ae30a4af89a6141cc4d71f33cL5-R5) [[4]](diffhunk://#diff-488618aa88a5d7e119fa584b670fbfc820332122276d6f5640c6f931057abf24L5-R5)

This change improves scalability and reproducibility for large datasets or high-cardinality columns by controlling the number of split candidates evaluated.